### PR TITLE
Increase BTG mining fee

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -109,7 +109,7 @@ export class AppComponent implements OnInit {
     } else if (this.chain.match(/btg/)) {
       this.network = 'livenet';
       this.coin = 'btg';
-      this.fee = 0.0001;
+      this.fee = 0.00015;
     } else {
       this.network = this.chain.replace('btc/', '');
       this.coin = 'btc';


### PR DESCRIPTION
0.0001 triggers an HTTP 400 Bad Request '66: min relay fee not met. Code:-26' on https://btgexplorer.com/api/tx/send for a transaction having 40 inputs and 1 output (11438 bytes). Increasing the fee to 0.00015 fixes this issue. At currect exchange rates, this fee increase is approx 0.02 USD per transaction: $385 * 0.00005